### PR TITLE
Update AirGradient-DIY.ino to add BME sensor status check.

### DIFF
--- a/AirGradient-DIY/AirGradient-DIY.ino
+++ b/AirGradient-DIY/AirGradient-DIY.ino
@@ -107,7 +107,10 @@ void setup()
   if (hasSHT)
     ag.TMP_RH_Init(0x44);
   if (hasBME)
-    bme.begin();
+    status = bme.begin();
+    if (!status) {
+      Serial.println("Could not find a valid BME280 sensor, check wiring!");
+      while (1);
 
 // Set static IP address if configured.
 #ifdef STATIC_IP


### PR DESCRIPTION
Added a status check after running bme.begin to make sure the BME sensor connects. I had a problem with this, and I needed to change the port it used to a differant one, and if this check was there, it would have saved me a lot of time debugging.